### PR TITLE
fix: match more file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ jobs:
 
 ### Default Behavior
 
-- Matched changed files `/\.(js|jsx|ts|tsx|json|css|md)` on the pull request
+- Matched changed files `/\.(js|jsx|ts|tsx|json|json5|css|less|scss|sass|html|md|mdx|vue)$/` on the pull request
 - Use root `.prettierrc` file for prettier configuration
 - Use root `.prettierignore` file for prettier ignore

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ export async function run(): Promise<void> {
   let changedFiles = await getAllChangedFiles()
 
   changedFiles = changedFiles.filter(f =>
-    /\.(js|jsx|ts|tsx|json|css|md)$/.test(f)
+    /\.(js|jsx|ts|tsx|json|json5|css|less|scss|sass|html|md|mdx|vue)$/.test(f)
   )
 
   const commentIdentifier = '<!-- prettier-check-comment -->'


### PR DESCRIPTION
`/\.(js|jsx|ts|tsx|json|json5|css|less|scss|sass|html|md|mdx|vue)$/`